### PR TITLE
www 의존없이 로그인 콜백을 처리하도록 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,30 +64,6 @@ Kakaotalk.logout(
 );
 ```
 
-#### loginCallback
-
-OpenURL method can only triggered once below iOS 10. so you have to workaround this situation with `loginCallback` method. It'll do same with the codes you defined on appDelegate.
-
-You should have ready to use custom URL Scheme. (You can check out it `cordova-plugin-customurlscheme`)
-
-```
-window.handleOpenURL = function (url) {
-  if (url.indexOf('kakao') === 0) {
-    Kakaotalk.loginCallback(url);
-  }
-}
-```
-
-If you use other platform except iOS, you can use `device.platform` value.
-
-```
-window.handleOpenURL = function (url) {
-  if (url.indexOf('kakao') === 0 && typeof device !== 'undefined' && device.platform.toLowerCase() === 'ios') {
-    Kakaotalk.loginCallback(url);
-  }
-}
-```
-
 #### isAvailable
 
 isAvailable using the `.isAvailable` method:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "id": "cordova-plugin-kakaotalk",
   "name": "cordova-plugin-kakaotalk",
-  "version": "1.0.25-hogangnono",
+  "version": "1.0.26-hogangnono",
   "description": "Cordova KakaoTalk Plugin",
   "cordova": {
     "id": "cordova-plugin-kakaotalk",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "id": "cordova-plugin-kakaotalk",
   "name": "cordova-plugin-kakaotalk",
-  "version": "1.0.24-hogangnono",
+  "version": "1.0.25-hogangnono",
   "description": "Cordova KakaoTalk Plugin",
   "cordova": {
     "id": "cordova-plugin-kakaotalk",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-kakaotalk" name="cordova-plugin-kakaotalk" version="1.0.21-hogangnono">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-kakaotalk" name="cordova-plugin-kakaotalk" version="1.0.26-hogangnono">
 
     <name>KakaoTalk</name>
     <description>KakaoTalk Cordova Plugin</description>

--- a/www/KakaoTalk.js
+++ b/www/KakaoTalk.js
@@ -12,10 +12,6 @@ var KakaoTalk = {
     logout: function (successCallback, errorCallback) {
         exec(successCallback, errorCallback, 'KakaoTalk', 'logout', []);
     },
-    /** iOS only */
-    loginCallback: function (url, successCallback, errorCallback) {
-        exec(successCallback, errorCallback, 'KakaoTalk', 'loginCallback', [ url ]);
-    },
     isAvailable: function () {
         return new Promise(function(resolve) {
             exec(function(result) {


### PR DESCRIPTION
<!--
- PR 제목은 단순 브랜치명이 아닌 작업내용의 대표문구 또는 이슈 제목이 들어가야합니다.
- 필수항목(*) 기재하지 않았을 경우, approve/merge 불가합니다.
- 주석은 내용 숙지 후 제거해도 무방합니다.
-->

# 관련 이슈*
<!-- 지라 링크를 달아주세요. 없을 경우 이슈에 대한 설명을 기재해주세요. -->

https://github.com/hogangnono/KakaoTalkCordovaPlugin/commit/419dd1f0c36f748d21f372761d4df94e8d218a86

``` js
// hogangnono-client/client/js/NativeApp.tsx

window.handleOpenURL = (url) => {
  // [workaround] iOS에서 openURL이 delegation되지 않는 문제가 있다. (왜그런지 모름...) 따라서 cordova에서
  //              해당 기능을 잡아서 KakaoTalkSDK에 돌려주는 동작을 수행한다. Android와는 상관 없다.
  if (url.indexOf('kakao') === 0 && window.device?.platform.toLowerCase() === 'ios') {
      window.KakaoTalk.loginCallback(url)
  }
}
```

위 코드는 카카오 SDK v1 + iOS 10 이하 버전에서 로그인을 지원하기 위한 사용했던 패턴으로,
카카오 SDK v2 적용 가이드에 맞게, 그리고 www에 의존하지 않도록 개선할 필요가 있습니다.

# 작업 내용*
<!-- 작업한 내용에 대해 자세하게 설명해주세요. -->

- 먼저 [카카오 로그인 가이드](https://developers.kakao.com/docs/latest/ko/kakaologin/ios#before-you-begin-setting-for-kakaotalk)에 따라 `AppDelegate`에서 커스텀 스킴을 받을 준비를 해야합니다.
   하지만, Cordova 플러그인에서는 일반적으로 `AppDelegate`를 직접 수정할 수 없기 때문에 위와 동일한 코드를 작성할 수 없습니다.
- 대신, `CordovaLib` > `CDVAppDelegate`에서 쏴주는 `CDVPluginHandleOpenURLNotification`을 구독해서 동일한 결과를 내는 코드를 작성할 수 있습니다. (`window.handleOpenURL`도 `CDVHandleOpenURL` 에서 해당 알림을 구독해서 실행됩니다.)
   ```objective-c
  - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
    {
        // all plugins will get the notification, and their handlers will be called
        [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
    }
   ```
  ``` swift
  override func pluginInitialize() {
      NotificationCenter.default.addObserver(self, selector: #selector(self.applicationLaunchedWithUrl(notification:)), name: .CDVPluginHandleOpenURL, object: nil)
  }
  
  @objc(applicationLaunchedWithUrl:)
  func applicationLaunchedWithUrl(notification: Notification) {
      guard let url = notification.object as? URL else {
          return
      }
      
      guard AuthApi.isKakaoTalkLoginUrl(url) else {
          return
      }
      
      _ = AuthController.handleOpenUrl(url: url)
  }
  ```
- 이제 www에서 `loginCallback`을 호출해주지 않아도, 플러그인에서 직접 커스텀 스킴을 처리해서 로그인을 완료할 수 있습니다.

# 체크리스트*
<!-- 확인해야할 사항을 정리하고 확인해주세요. -->

- [x] PR 모든 항목을 빠짐없이 작성했습니다. (제목, 담당자, 라벨, 마일스톤 등)
- [x] 페이즈 별 앱 적용 전후 환경에서 각각 테스트하였습니다.

# 기타
<!-- 기타 공유할 사항이 있다면 설명해주세요. -->

없음
